### PR TITLE
Add Microsoft Clarity analytics tracking

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -14,6 +14,13 @@
     <link rel="canonical" href="{{ site.baseurl }}{{ page.url }}">
     <link rel="stylesheet" href="{{ site.baseurl }}/assets/style.css">
     <link rel="stylesheet" href="{{ site.baseurl }}/assets/code-theme.css">
+    <script type="text/javascript">
+        (function(c,l,a,r,i,t,y){
+            c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+            t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+            y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+        })(window, document, "clarity", "script", "vua335d0rm");
+    </script>
 </head>
 
 <body>


### PR DESCRIPTION
## Summary
- Adds Microsoft Clarity tracking script (ID: `vua335d0rm`) to `_includes/head.html`
- Loads async on all pages via the shared `<head>` include
- No other tracking existed on the site previously