### PR TITLE
fix: use absolute paths for iframe/image sources in slides

### DIFF
--- a/slides/agents-talk.html
+++ b/slides/agents-talk.html
@@ -283,7 +283,7 @@
         <div class="slide-content center gap-sm">
             <h2 class="reveal">Let's <span class="em-green">see</span> it work.</h2>
             <div class="embed-frame reveal">
-                <iframe src="assets/blog/agents/messages-loop.html"></iframe>
+                <iframe src="/assets/blog/agents/messages-loop.html"></iframe>
             </div>
         </div>
     </section>
@@ -327,7 +327,7 @@
         <div class="slide-content center gap-sm">
             <h2 class="reveal">Inside <span class="em-green">execute()</span>.</h2>
             <div class="embed-frame reveal">
-                <iframe src="assets/blog/agents/tool-dispatch.html"></iframe>
+                <iframe src="/assets/blog/agents/tool-dispatch.html"></iframe>
             </div>
         </div>
     </section>
@@ -416,7 +416,7 @@ deploy/<span class="str">SKILL.md</span>
         <div class="slide-content center gap-sm">
             <h2 class="reveal">Let's <span class="em-green">see</span> it in the loop.</h2>
             <div class="embed-frame reveal">
-                <iframe src="assets/blog/agents/skill-loading.html"></iframe>
+                <iframe src="/assets/blog/agents/skill-loading.html"></iframe>
             </div>
         </div>
     </section>
@@ -445,7 +445,7 @@ deploy/<span class="str">SKILL.md</span>
         <div class="slide-content center gap-sm">
             <h2 class="reveal">Everything so far.</h2>
             <div class="embed-frame reveal">
-                <iframe src="assets/blog/agents/wrapup-diagram.html"></iframe>
+                <iframe src="/assets/blog/agents/wrapup-diagram.html"></iframe>
             </div>
         </div>
     </section>
@@ -499,7 +499,7 @@ deploy/<span class="str">SKILL.md</span>
     <section class="slide">
         <div class="slide-content center gap-sm">
             <div class="embed-frame reveal">
-                <iframe src="assets/blog/agents/gateway-diagram.html"></iframe>
+                <iframe src="/assets/blog/agents/gateway-diagram.html"></iframe>
             </div>
         </div>
     </section>
@@ -517,7 +517,7 @@ deploy/<span class="str">SKILL.md</span>
     <section class="slide">
         <div class="slide-content center gap-sm">
             <div class="embed-frame reveal">
-                <iframe src="assets/blog/agents/memory-diagram.html"></iframe>
+                <iframe src="/assets/blog/agents/memory-diagram.html"></iframe>
             </div>
         </div>
     </section>
@@ -527,7 +527,7 @@ deploy/<span class="str">SKILL.md</span>
         <div class="slide-content center gap-sm">
             <h2 class="reveal">The full picture.</h2>
             <div class="embed-frame reveal">
-                <iframe src="assets/blog/agents/full-diagram.html"></iframe>
+                <iframe src="/assets/blog/agents/full-diagram.html"></iframe>
             </div>
         </div>
     </section>
@@ -558,7 +558,7 @@ deploy/<span class="str">SKILL.md</span>
     <section class="slide">
         <div class="slide-content center gap-sm">
             <h2 class="reveal">OpenClaw in <span class="em-green">action</span>.</h2>
-            <img src="assets/blog/agents/open-claw-example.png" alt="OpenClaw showing tool calls" class="reveal" style="max-height: min(60vh, 420px); border-radius: 10px; border: 1px solid var(--border);"/>
+            <img src="/assets/blog/agents/open-claw-example.png" alt="OpenClaw showing tool calls" class="reveal" style="max-height: min(60vh, 420px); border-radius: 10px; border: 1px solid var(--border);"/>
             <p class="reveal" style="color: var(--text-muted); font-size: var(--small-size);">Tools firing, memory search, exec — the loop in real life.</p>
         </div>
     </section>
@@ -569,11 +569,11 @@ deploy/<span class="str">SKILL.md</span>
             <h1 class="reveal">Thanks!</h1>
             <div class="reveal" style="display: flex; gap: clamp(2rem, 5vw, 5rem); align-items: center; margin-top: var(--content-gap);">
                 <div style="text-align: center;">
-                    <img src="assets/blog/agents/qr-substack.png" alt="Substack QR" style="width: min(25vw, 160px); height: auto; border-radius: 8px;"/>
+                    <img src="/assets/blog/agents/qr-substack.png" alt="Substack QR" style="width: min(25vw, 160px); height: auto; border-radius: 8px;"/>
                     <p style="color: var(--accent-cyan); font-family: var(--font-mono); font-size: var(--small-size); margin-top: 8px;">Substack</p>
                 </div>
                 <div style="text-align: center;">
-                    <img src="assets/blog/agents/qr-linkedin.png" alt="LinkedIn QR" style="width: min(25vw, 160px); height: auto; border-radius: 8px;"/>
+                    <img src="/assets/blog/agents/qr-linkedin.png" alt="LinkedIn QR" style="width: min(25vw, 160px); height: auto; border-radius: 8px;"/>
                     <p style="color: var(--accent-cyan); font-family: var(--font-mono); font-size: var(--small-size); margin-top: 8px;">LinkedIn</p>
                 </div>
             </div>


### PR DESCRIPTION
Slides are served from /slides/ but assets live at /assets/. Relative paths resolved to /slides/assets/ causing 404s.

Authored-By: Emmanuel Orozco <indi3.rok@gmail.com>